### PR TITLE
Fix for `No valid linked folder path`

### DIFF
--- a/src/modules/resolver.ts
+++ b/src/modules/resolver.ts
@@ -209,7 +209,7 @@ export default class NoteResolver {
       return false;
     }
 
-    const newFolderPath = this.getFolderPath(file, false),
+    const newFolderPath = this.getFolderPath(file, true),
       folderExist = newFolderPath && (await this.vault.exists(newFolderPath));
     if (folderExist) {
       log.info(


### PR DESCRIPTION
I believe [this commit](https://github.com/aidenlx/folder-note-core/commit/68d2e73812121bc192cb9591c69d57376792c14a) introduced a bug, that prevents converting from Note to Folder Note

![image](https://user-images.githubusercontent.com/2822102/142762070-d6d476a3-3eb2-4566-b8bb-cabc524255bc.png)
